### PR TITLE
Fix compatibility with recent traces versions

### DIFF
--- a/lib/traces/backend/open_telemetry/interface.rb
+++ b/lib/traces/backend/open_telemetry/interface.rb
@@ -16,7 +16,7 @@ module Traces
 			TRACER = ::OpenTelemetry.tracer_provider.tracer(Traces::Backend::OpenTelemetry.name, Traces::Backend::OpenTelemetry::VERSION)
 			
 			module Interface
-				def trace(name, attributes: nil, &block)
+				def trace(name, resource: nil, attributes: nil, &block)
 					TRACER.in_span(name, attributes: attributes&.transform_keys(&:to_s), &block)
 				end
 				

--- a/test/traces/backend/open_telemetry.rb
+++ b/test/traces/backend/open_telemetry.rb
@@ -18,6 +18,10 @@ Traces::Provider(MyClass) do
 	def my_method_without_attributes(arguments)
 		Traces.trace("my_method_without_attributes") {}
 	end
+
+	def my_method_with_resource(argument)
+		Traces.trace("my_method_with_resource", resource: "my_resource") {}
+	end
 	
 	def my_method_with_exception
 		Traces.trace("my_method_with_exception") {raise "Error"}
@@ -55,6 +59,12 @@ describe Traces::Backend::OpenTelemetry do
 		expect(Traces::Backend::OpenTelemetry::TRACER).to receive(:start_span)
 		
 		instance.my_method_without_attributes(10)
+	end
+
+	it "can invoke trace wrapper with a resource" do
+		expect(Traces::Backend::OpenTelemetry::TRACER).to receive(:start_span)
+
+		instance.my_method_with_resource(10)
 	end
 	
 	it "can invoke trace wrapper with exception" do


### PR DESCRIPTION
This gem currently errors at runtime with `ArgumentError: unknown keyword: :resource` when used with certain instrumentation (e.g. [this trace call in async-http](https://github.com/socketry/async-http/blob/58c38c3109fe131c7c621d543f3ac37bba8b66b3/lib/async/http/server.rb#L97)). The gem depends on `traces` version `~> 0.10`, but `Interface#trace` is missing the `resource:` parameter introduced in version `0.5.0`. Update the interface to accept this keyword.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
