### PR TITLE
Add support for context propagation.

### DIFF
--- a/lib/traces/backend/open_telemetry/context.rb
+++ b/lib/traces/backend/open_telemetry/context.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2021-2025, by Samuel Williams.
+
+require "opentelemetry"
+require "traces/context"
+
+module Traces
+	module Backend
+		module OpenTelemetry
+			class Context < Traces::Context
+				def initialize(*arguments, **options, context: nil)
+					super(*arguments, **options)
+					@context = context
+				end
+				
+				attr :context
+			end
+		end
+	end
+end


### PR DESCRIPTION
After considering the options, this might be the best one.

Inter-process distributed tracing is distinctly different than inter-process tracing in Open Telemetry and I dislike that. I even tried using a propagator and it didn't serialize all the context state.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
